### PR TITLE
WORD_FONTを指定してコンパイルするようにした

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,6 @@ script:
   - make
   - ./configure --enable-luatex
   - make
+  - export WORD_FONT=hiragino-pron
+  - make clean
+  - make


### PR DESCRIPTION
`.travis.yml`を変更し、`WORD_FONT`が設定されている場合のコンパイルをするようにした。


### 注意

このブランチは https://github.com/WORD-COINS/texfiles/pull/13 がマージされてから、`texfiles`の参照コミットを修正してマージする。
（このままマージしてはならない）