### PR TITLE
fix README and hinagata

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ WORDの記事の雛形
 鍵登録が出来ない場合や、WORD編集部以外のメンバーに執筆してもらう場合に利用してもらって下さい。
 
 # 使い方
+
+## macOS・Linux
 1. `git clone https://github.com/WORD-COINS/article-template.git`
 2. `cd ./article-template`
 3. `git submodule update --init`
@@ -16,6 +18,16 @@ WORDの記事の雛形
 7. `autoconf`
 8. `./configure`
 9. `make`
+
+## Windows
+1. `git clone https://github.com/WORD-COINS/article-template.git`
+2. `cd ./article-template`
+3. `git submodule update --init`
+4. `cd ./articles`
+5. `cp -r ./hinagata ./my-article-name`
+6. `cd ./my-article-name`
+7. `cmake -DENABLE_LUATEX=OFF .`
+8. `cmake --build .`
 
 これで`main.pdf`が生成されれば成功です。
 あとは`main.tex`を編集すれば記事が出来ます。
@@ -40,8 +52,13 @@ WORD編集部の人間ではない場合、著者の前に付く「文　編集�
 
 # word-lua
 WORDでは新たにLuaLaTeXが使えるようになりました。
-使い方は、上記の**使い方8.**で`./configure --enable-luatex`としてください。
+
+## macOS・Linux
+上記の**使い方8.**で`./configure --enable-luatex`としてください。
 以降は`make`のみでOKです。
+
+## Windows
+**使い方7.**で`cmake -DENABLE_LUATEX=ON .`としてください。
 
 ## 「文　編集部」の消し方
 LuaLaTeXでは「文　編集部」は以下のコマンドでも消すことができます。

--- a/articles/hinagata/main.tex
+++ b/articles/hinagata/main.tex
@@ -4,9 +4,8 @@
   commentstyle=\textit,
   frame=trBL,
   numbers=left,
-  breaklines=true,                 % sets automatic line breaking
-  language=TeX,                 % the language of the code
-  title=\lstname                   % show the filename of files included with \lstinputlisting; also try caption instead of title
+  breaklines=true,
+  title=\lstname,
 }
 \usepackage{fancybox}
 \usepackage{url}
@@ -20,7 +19,9 @@
 
 \section{まずはじめに}
 
-\subsection{デフォルトオプション: p\LaTeX を使う}
+\subsection{p\LaTeX を使う}
+
+\subsubsection{macOS・Linux}
 
 $article\_name$は適当な名前として、以下のようなコマンドでブランチを分けましょう。
 
@@ -34,27 +35,53 @@ autoconf
 ./configure
 \end{lstlisting}
 
+\subsubsection{Windows}
+
+WORDクラスファイルはWindowsでもコンパイルすることができます。
+次のように\lstinline|cmake|を使います。
+
+\begin{lstlisting}[mathescape]
+git submodule update --init
+git checkout -b personal/$username$/$article\_name$
+cd ./articles
+cp -r ./hinagata ./my-article-name
+cd ./my-article-name
+cmake -DENABLE_LUATEX=OFF .
+\end{lstlisting}
+
 \subsection{選択: Lua\LaTeX を使う}
 
-WORD では新たに LuaLaTeX が使えるようになりました。
+WORDでは新たにLua\LaTeX が使えるようになりました。
 使い方は、\lstinline|./configure|のかわりに\lstinline|./configure --enable-luatex|としてください。
+Windowsの場合は、\lstinline|cmake -DENABLE_LUATEX=OFF .|のかわりに
+\lstinline|cmake -DENABLE_LUATEX=ON .|としてください。
 
 \section{記事を書く}
 
 記事を書いたら、\lstinline|make|コマンドでビルドできます。
+Windowsの場合は\lstinline|cmake|コマンドでビルドします。
+
+\subsection{macOS・Linux}
 
 \begin{lstlisting}
 git add *
 make
 \end{lstlisting}
 
+\subsection{Windows}
+
+\begin{lstlisting}
+git add *
+cmake --build .
+\end{lstlisting}
+
 これで\ovalbox{main.pdf}が生成されれば成功です。
 あとは\ovalbox{main.tex}を編集すれば記事が出来ます。
 
-\section{Git サーバにpushする}
+\section{Gitサーバにpushする}
 
 記事のキリの良いところで\lstinline|git push|するといいのですが、最初のpushの時には、
-origin\footnote{ここではGitサーバである\texttt{gitolite.word-ac.net}のことです}%
+origin\footnote{ここではWORDのGitサーバである\url{gitolite.word-ac.net}のことです}%
 に新しいブランチを登録する必要があります。それは以下のようにしましょう。
 
 \begin{lstlisting}[mathescape]
@@ -70,19 +97,19 @@ slackを見ていない場合は、\url{https://jenkins.word-ac.net/job/LaTeX/}�
 
 編集作業をしていると、レイアウトの問題で偶数頁から開始していただくことがあります。その場合の対処法は、\TeX の処理系によって以下のように異なります。
 
-\subsubsection{platex を使う場合}
+\subsubsection{p\LaTeX を使う場合}
 
 その場合は、プレアンブルに以下を追加してください。
 
-\begin{lstlisting}[mathescape]
+\begin{lstlisting}[language=TeX, mathescape]
 \setcounter{page}{2}
 \end{lstlisting}
 
-\subsubsection{LuaLaTeX を使う場合}
+\subsubsection{Lua\LaTeX を使う場合}
 
 \lstinline|\documentclass|のオプションに\ovalbox{swapheader}をつけることで簡単にできます。
 
-\begin{lstlisting}[mathescape]
+\begin{lstlisting}[language=TeX, mathescape]
 \documentclass[swapheader]{word-lua}
 \end{lstlisting}
 


### PR DESCRIPTION
Fix #27 

### 変更点

- `README.md` にWindows向けのコンパイル方法を追加
- hinagataにもWindows向けの情報を追加