### PR TITLE
Jenkinsのスクリプトを追加

### DIFF
--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Jenkinsから呼び出されて、articlesの中にあるフォルダへ移動して`make`を実行します。
+# `make`に成功した場合、PDFはpushされた日時とコミットIDに基づいて表示用のフォルダへコピーされます。
+
+set -e
+
+# Checkout the branch
+git checkout "$branch"
+git submodule update --init --recursive
+
+# Determine the article's directory (the first directory in "articles" that is not "hinagata")
+cd articles
+for i in *; do
+  if [ "$i" != "hinagata" ]; then
+    article_dir="$i"
+    break
+  fi
+done
+
+if [ -z "$article_dir" ]; then
+  echo "Article's directory not found. Aborting."
+  exit 1
+fi
+
+# cd and make
+cd "$article_dir"
+WORD_FONT=hiragino-pron make
+
+# Copy the artifact
+if [ -e main.pdf ]; then
+  mkdir -p "$WORKSPACE/artifacts/$repository/$branch"
+  cp main.pdf "$WORKSPACE/artifacts/$repository/$branch/${push_date}_${revision:0:7}.pdf"
+fi
+
+# Back to the repository root
+cd ../..

--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -32,6 +32,3 @@ if [ -e main.pdf ]; then
   mkdir -p "$WORKSPACE/artifacts/$repository/$branch"
   cp main.pdf "$WORKSPACE/artifacts/$repository/$branch/${push_date}_${revision:0:7}.pdf"
 fi
-
-# Back to the repository root
-cd ../..

--- a/jenkins/notify_slack.sh
+++ b/jenkins/notify_slack.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+# makeに成功した場合、Slackへ通知を行います。
+# ただし、Slackのwebhook URLは環境変数`$slack_webhook_url`をJenkinsジョブで定義します。
+# （このスクリプトはGitHubで公開されるため、SlackのURLが外部に流出するのを防ぐため）
+
+set -e
+
+if [ -e "$WORKSPACE/artifacts/$repository/$branch/${push_date}_${revision:0:7}.pdf" ]; then
+  result="SUCCESS"
+else
+  result="FAILURE"
+fi
+
+pdf_url="${JOB_URL}ws/artifacts/${repository}/${branch}/${push_date}_${revision:0:7}.pdf"
+console_url="${BUILD_URL}console"
+param="repository=${repository}&branch=${branch}&revision=${revision}&result=${result}&console_url=${console_url}&pdf_url=${pdf_url}&job_name=${JOB_NAME}&build_number=${BUILD_NUMBER}&build_url=${BUILD_URL}"
+
+gitiles_base_url="https://gitiles.word-ac.net/"
+gitiles_url="${gitiles_base_url}${repository}/+/${revision}"
+
+channel="jenkins"
+username="jenkins"
+
+fields=`cat <<EOS
+{
+  "title": "Status",
+  "value": "${result}",
+  "short": "true"
+},
+{
+  "title": "Repository",
+  "value": "${repository}",
+  "short": "true"
+},
+{
+  "title": "Branch",
+  "value": "${branch}",
+  "short": "true"
+},
+{
+  "title": "Revision",
+  "value": "<${gitiles_url}|${revision}>",
+  "short": "true"
+},
+{
+  "title": "Compile Log",
+  "value": "${console_url}",
+  "short": "true"
+}
+EOS
+`
+
+case "${result}" in
+  "SUCCESS")
+    color="good"
+    fields="${fields},
+    {
+      \"title\": \"PDF\",
+      \"value\": \"${pdf_url}\",
+      \"short\": \"true\"
+    }"
+    ;;
+  *) color="danger" ;;
+esac
+
+payload=`cat <<EOS
+{
+  "channel":  "${channel}",
+  "username": "${username}",
+  "attachments": [
+    {
+      "fallback": "${JOB_NAME} Build #${BUILD_NUMBER} ${result}",
+      "title": "${JOB_NAME} Build #${BUILD_NUMBER}",
+      "title_link": "${BUILD_URL}",
+      "color": "${color}",
+      "fields": [${fields}]
+    }
+  ]
+}
+EOS
+`
+
+curl -s -X POST --data-urlencode "payload=${payload}" "${slack_webhook_url}"


### PR DESCRIPTION
JenkinsにあったビルドスクリプトとSlackの通知スクリプトを雛形へ移動して管理することにした。Jenkinsではこちらのスクリプトを呼び出すようにする。
ただし、すぐにJenkinsを書き換えると古いリポジトリをビルドできなくなるので、しばらくは `if` 文で `./jenkins/*.sh` があればそれを実行、なければ従来のスクリプトを実行という仕組みにしている。