### PR TITLE
fix appveyor.yml and travis.yml

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,9 +1,9 @@
 image: Visual Studio 2015
 environment:
-  PATH: '%PATH%;C:\texlive\2016\bin\win32;C:\Program Files\CMake\bin'
+  PATH: '%PATH%;C:\texlive\2017\bin\win32;C:\Program Files\CMake\bin'
 cache:
-  - 'C:\texlive\2016\texmf-var\fonts\cache'
-  - 'C:\texlive\2016\texmf-var\luatex-cache'
+  - 'C:\texlive\2017\texmf-var\fonts\cache'
+  - 'C:\texlive\2017\texmf-var\luatex-cache'
 artifacts:
   - path: .\articles\hinagata\main-ptex.pdf
     name: pTeX

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ dist: trusty
 sudo: false
 cache:
   directories:
-    - "$HOME/Library/texlive/2016basic/texmf-var/luatex-cache"
-    - "$HOME/texlive/2016/texmf-var/luatex-cache"
+    - "$HOME/Library/texlive/2017basic/texmf-var/luatex-cache"
+    - "$HOME/texlive/2017/texmf-var/luatex-cache"
 before_install:
   - wget https://raw.githubusercontent.com/y-yu/install-tex-travis/master/install-tex.sh
   - wget https://raw.githubusercontent.com/y-yu/install-tex-travis/master/tlmgr.sh


### PR DESCRIPTION
- `appveyor.yml`と`travis.yml`がTeXLive2016のフォルダを参照していたので修正した