### PR TITLE
Fail building if the repository has two or more article directories

### DIFF
--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -9,12 +9,14 @@ set -e
 git checkout "$branch"
 git submodule update --init --recursive
 
-# Determine the article's directory (the first directory in "articles" that is not "hinagata")
+# Determine the article's directory
 cd articles
 for i in *; do
-  if [ "$i" != "hinagata" ]; then
+  if [ "$i" != "hinagata" ] && [ "$article_dir" = "" ]; then
     article_dir="$i"
-    break
+  elif [ "$i" != "hinagata" ]; then
+    echo "There are some aritcle's directories. Aborting."
+    exit 1
   fi
 done
 

--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -3,7 +3,7 @@
 # Jenkinsから呼び出されて、articlesの中にあるフォルダへ移動して`make`を実行します。
 # `make`に成功した場合、PDFはpushされた日時とコミットIDに基づいて表示用のフォルダへコピーされます。
 
-set -e
+set -ex
 
 # Checkout the branch
 git checkout "$branch"


### PR DESCRIPTION
- ひとつのリポジトリいくつかの記事ディレクトリがある場合は処理を中止するようにした
  - どちらかのディレクトリがビルドされると一見成功し、どうしてなのかが分かりにくいため