### PR TITLE
Fix using LuaLaTeX

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,18 @@ WORD編集部の人間ではない場合、著者の前に付く「文　編集�
 
 WORDでは新たにLuaLaTeXが使えるようになりました。
 
-### macOS・Linux
+### macOS・Linux・Windows
 
-上記の **使い方(7)** で`LATEXMKFLAG=-lualatex make`としてください。
-以降は`make`のみでOKです。
+1. **使い方(7)** の`make`の前に`Makefile`をエディターで開く
+2. `LATEXMKFLAG`の部分を次のように書き換える
 
-### Windows
+    ```diff
+    - LATEXMKFLAG += -halt-on-error
+    + LATEXMKFLAG += -halt-on-error -lualatex
+    ```
+3. `make`を実行する
 
-**使い方(7)** で`LATEXMKFLAG=-lualatex make`としてください。
+このようにすることでJenkins上でもLuaLaTeXが利用されるようになります。
 
 ## 質問
 

--- a/articles/hinagata/Makefile
+++ b/articles/hinagata/Makefile
@@ -1,6 +1,10 @@
 MAKE         = make
 LATEXMK      = latexmk
+
 LATEXMKFLAG += -halt-on-error
+# LuaLaTeXを利用するときは上の行をコメントアウトし、下記の行をアンコメントする
+# LATEXMKFLAG += -halt-on-error -lualatex
+
 CP           = cp
 RM           = rm
 

--- a/articles/hinagata/main.tex
+++ b/articles/hinagata/main.tex
@@ -3,6 +3,7 @@
 % 次の\documentclassをアンコメントします。
 % \documnetclass[evenstart]{word}
 
+\usepackage[svgnames]{xcolor}
 \usepackage{listings}
 \lstset{
   basicstyle=\ttfamily,
@@ -11,6 +12,16 @@
   numbers=left,
   breaklines=true,
   title=\lstname,
+}
+
+\definecolor{diffstart}{named}{Grey}
+\definecolor{diffincl}{named}{Green}
+\definecolor{diffrem}{named}{OrangeRed}
+
+\lstdefinelanguage{diff}{
+  morecomment=[f][\color{diffstart}]{@@},
+  morecomment=[f][\color{diffincl}]{+\ },
+  morecomment=[f][\color{diffrem}]{-\ },
 }
 \usepackage{fancybox}
 \usepackage{url}
@@ -65,12 +76,21 @@ make
 \subsection{Lua\LaTeX を使う}
 
 WORDでは新たにLua\LaTeX が使えるようになりました。
+次のようにすることで利用できます。
 
-\begin{description}
-  \item[macOS・Linux] \lstinline|make|のかわりに\lstinline|LATEXMKFLAG=-lualatex make|を利用する。
- 
-  \item[Windows] \lstinline|make|の前に\lstinline|set LATEXMKFLAG=-lualatex|として、環境変数を設定する。
-\end{description}
+\begin{enumerate}
+  \item \lstinline|make|の前に\ovalbox{Makefile}をエディターで開く
+  \item \lstinline|LATEXMKFLAG|の部分を次のように書き換える
+\begin{lstlisting}[language=diff]
+- LATEXMKFLAG += -halt-on-error
++ LATEXMKFLAG += -halt-on-error -lualatex
+\end{lstlisting}
+
+  \item \lstinline|make|を実行する
+\end{enumerate}
+
+これ以降は\lstinline|make|のみでLua\LaTeX 利用されますし、
+この状態でGitにpushするとJenkins上でもLua\LaTeX が利用されます。
 
 \section{記事を書く}
 
@@ -115,7 +135,7 @@ sudo kanji-config-updmap-sys hiragino-elcapitan-pron
 \subsection{Lua\LaTeX の場合}
 
 \begin{description}
-  \item[macOS・Linux] \lstinline|LATEXMKFLAG=-lualatex make|のかわりに\lstinline|WORD_FONT=hiragino-pron LATEXMKFLAG=-lualatex make|を実行する
+  \item[macOS・Linux] \lstinline|make|のかわりに\lstinline|WORD_FONT=hiragino-pron make|を実行する
 
   \item[Windows] \lstinline|make|の前に\lstinline|set WORD_FONT=hiragino-pron|を実行する
 \end{description}


### PR DESCRIPTION
- 今までは、LuaLaTeXを利用する方法として`make`の際に環境変数を拡張する方法しか書いていなかったため、Jenkinsでは単に`make`のみが実行されLuaLaTeXを利用できなかった
- そこでLuaLaTeXを利用する際には`Makefile`を編集するように案内を記述した