### PR TITLE
Remove usage of an Action to get job status

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,9 +53,8 @@ jobs:
           WORD_FONT=sourcehan-jp make
           aws s3 --endpoint-url=https://minio.k8s.word-ac.net cp ./main.pdf s3://article-bucket/$REPO_NAME-$ARTICLE_NAME.pdf
 
-      - uses: technote-space/workflow-conclusion-action@v2
       - name: Notify Slack
         if: always()
         run: ./scripts/notify_slack.sh
         env:
-          status: ${{ env.WORKFLOW_CONCLUSION }}
+          status: ${{ job.status }}


### PR DESCRIPTION
## 概要

closes #65

記事ビルドの結果を取得するために使っていた `technote-space/workflow-conclusion-action@v2` の利用をやめ、`${{ job.status }}` で結果を得るようにします。

## 動作確認

https://github.com/nektos/act を入れた自分の環境で `$ act -s PDF_BUILD_NOTIFY_URL="ここに自分の個人 Slack の Webhook URL が入る"` を実行し、以下の場合の動作を確認した。
* `ci.yaml` の `jobs.build-article.steps` を `exit 0` を実行するだけの step と Slack 通知の step のみにし、success 時の動作を検証した。
* `ci.yaml` の `jobs.build-article.steps` を `exit 1` を実行するだけの step と Slack 通知の step のみにし、failure 時の動作を検証した。