### PR TITLE
Change revision link to head to its diff

### DIFF
--- a/scripts/notify_slack.sh
+++ b/scripts/notify_slack.sh
@@ -8,7 +8,7 @@ set -e
 GITHUB_HOST_URL="https://github.com"
 REPO_URL="${GITHUB_HOST_URL}/${REPO_NAME}"
 BUILD_URL="${GITHUB_HOST_URL}/${REPO_NAME}/actions/runs/${RUN_ID}"
-COMMIT_URL="${REPO_URL}/tree/${GITHUB_SHA}"
+COMMIT_URL="${REPO_URL}/commit/${GITHUB_SHA}"
 GIT_BRANCH="${GITHUB_REF##*/}"
 # TODO: PDF_URL を PDF への直リンにしたい
 # PDF_URL=""


### PR DESCRIPTION
## 概要

Slack 通知の Revision の箇所で、当該 Revision におけるリポジトリのファイルを表示するページへリンクさせていたところを、そのコミットによる差分を表示するページへリンクさせるようにします。

## 動作確認

https://github.com/nektos/act を入れた自分の環境で `$ act -s PDF_BUILD_NOTIFY_URL="ここに自分の個人 Slack の Webhook URL が入る"` を実行し、Revision の部分のリンクから差分を表示するページへ飛ぶことができること
