### PR TITLE
[fix] replace deprecated command `set-output`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - name: extract branch name
         shell: bash
-        run: echo "::set-output name=branch::${GITHUB_REF#refs/heads/}"
+        run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
         id: extract_branch
 
       - name: build master branch
@@ -41,7 +41,7 @@ jobs:
         shell: bash
         run: |
           if [[ ${{ steps.extract_branch.outputs.branch }} =~ ^articles/.*$ ]]; then
-          echo "::set-output name=match::true"
+          echo "match=true" >> $GITHUB_OUTPUT
           fi
         id: branch_regex
 


### PR DESCRIPTION
`set-output` コマンドが7月くらいから動かなくなるらしいので、書き換え。

[この辺](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-setting-an-output-parameter) 参考に書き換えを行った。