### PR TITLE
dockerを使って各記事をコンパイルできるように変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,9 +177,12 @@ wordクラスを使う場合、`documentclass`のオプションに`noheader`と
 
 ### Dockerによるコンパイル
 手元でのビルドに失敗したり、TeXLiveを入れたくなかったりする人はDockerイメージを使ってビルドすることもできます。
-```
-$ docker-compose up
-```
+
+#### 全体のコンパイル
+リポジトリのルートディレクトリで`docker compose up`しましょう。
+
+#### 各記事のコンパイル
+目次と裏表紙が必要ない場合は`articles/`以下の記事ディレクトリに`cd`して`docker compose up`しましょう。
 
 ### GitHub Actionsによるコンパイル
 特定のブランチ名でBitBucketにpushするとGitHub Actionsを使って記事をビルドすることができます。

--- a/articles/hinagata/docker-compose.yml
+++ b/articles/hinagata/docker-compose.yml
@@ -2,7 +2,8 @@ version: '3.4'
 services:
   article_build:
     image: ghcr.io/word-coins/latex-build:latest
-    command: "/bin/sh -c 'fc-cache && cd articles/current_article && WORD_FONT=sourcehan-jp make'"
+    command: "bash -c 'fc-cache && WORD_FONT=sourcehan-jp make'"
+    working_dir: /workdir/articles/current_article
     volumes:
       - ../..:/workdir
       - .:/workdir/articles/current_article

--- a/articles/hinagata/docker-compose.yml
+++ b/articles/hinagata/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.4'
+services:
+  article_build:
+    image: ghcr.io/word-coins/latex-build:latest
+    command: "/bin/sh -c 'fc-cache && cd articles/current_article && WORD_FONT=sourcehan-jp make'"
+    volumes:
+      - ../..:/workdir
+      - .:/workdir/articles/current_article


### PR DESCRIPTION
#75 を解決するために，`hinagata`に`docker-compose.yml`を追加し，記事内で`docker compose up`を叩いたらその記事のみがビルドされるようにしました．