### PR TITLE
mdファイルのビルド用docker-composeを追加

### DIFF
--- a/articles/hinagata-markdown/docker-compose.yml
+++ b/articles/hinagata-markdown/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.4'
+services:
+  article_build:
+    image: ghcr.io/word-coins/latex-build:latest
+    command: "bash -c 'make pandoc && WORD_FONT=sourcehan-jp make'"
+    working_dir: /workdir/articles/current_article
+    volumes:
+      - ../..:/workdir
+      - .:/workdir/articles/current_article


### PR DESCRIPTION
hinagata同様にhinagata-markdownにもビルド用の`docker-compose.yml`を追加しました。

1つ疑問点として
> main.texがあるとmarkdown変換処理が行なわれないため、main.texをコミットしないように気を付けてください。

とあるので、`docker compose up`の実行毎に`main.tex`を削除する処理を追加するかどうか悩みました。
手元環境では`main.tex`がある状態で`make pandoc`を実行しても`main.tex`の更新が行われている様なので追加していませんが、あったほうが確実でしょうか？