### PR TITLE
Pandoc3.2.1以降の画像埋め込み対応

### DIFF
--- a/articles/hinagata-markdown/word-template.latex
+++ b/articles/hinagata-markdown/word-template.latex
@@ -7,6 +7,19 @@
 % ここに\usepackageなどを書いても無意味です。
 % リポジトリ直下のmain.texに書きましょう。
 
+% Pandoc3.2.1以降の画像埋め込み対応
+\makeatletter
+\newsavebox\pandoc@box
+\newcommand*\pandocbounded[1]{% scales image to fit in text height/width
+  \sbox\pandoc@box{#1}%
+  \Gscale@div\@tempa{\textheight}{\dimexpr\ht\pandoc@box+\dp\pandoc@box\relax}%
+  \Gscale@div\@tempb{\linewidth}{\wd\pandoc@box}%
+  \ifdim\@tempb\p@<\@tempa\p@\let\@tempa\@tempb\fi% select the smaller of both
+  \ifdim\@tempa\p@<\p@\scalebox{\@tempa}{\usebox\pandoc@box}%
+  \else\usebox{\pandoc@box}%
+  \fi%
+}
+
 \begin{document}
 
 \lstset{

--- a/articles/hinagata-markdown/word-template.latex
+++ b/articles/hinagata-markdown/word-template.latex
@@ -7,6 +7,8 @@
 % ここに\usepackageなどを書いても無意味です。
 % リポジトリ直下のmain.texに書きましょう。
 
+\begin{document}
+
 % Pandoc3.2.1以降の画像埋め込み対応
 \makeatletter
 \newsavebox\pandoc@box
@@ -19,8 +21,6 @@
   \else\usebox{\pandoc@box}%
   \fi%
 }
-
-\begin{document}
 
 \lstset{
   basicstyle=\ttfamily,


### PR DESCRIPTION
pandoc3.2.1以降で画像が含まれるmarkdownを変換する際に`\pandocbounded`というマクロが付与されます。
texのテンプレート側がこれに対応する必要があったので追記しました。

book56レポジトリにもプルリクを出しましたが、今後のためにこちらもお願いします。